### PR TITLE
fix(i18n): adds missing translation for play sound label

### DIFF
--- a/src/renderer/i18n/locales/en-US/editor.json
+++ b/src/renderer/i18n/locales/en-US/editor.json
@@ -4,6 +4,7 @@
     "bindings": "Bindings",
     "url": "URL",
     "page": "Page",
+    "play_sound": "Play sound",
     "label": "Label",
     "background_color": "Background Color",
     "background_url": "Background URL",


### PR DESCRIPTION
# Fix
Adds missing translation for Play Sound Label

## Screenshots

### Before
![image](https://user-images.githubusercontent.com/33161939/197318455-17ab1cec-2757-4deb-8b38-60362abd19e6.png)


### After
![image](https://user-images.githubusercontent.com/33161939/197318463-2849d531-fa75-4c58-976f-04cf228555cc.png)
