### PR TITLE
fix(hotkey): allow hotkey with commas

### DIFF
--- a/src/renderer/components/Form/InputBindings/index.tsx
+++ b/src/renderer/components/Form/InputBindings/index.tsx
@@ -39,7 +39,7 @@ const InputBindings: React.FC<InputBindingsProps> = ({
 
   const handleEnd = useCallback(
     (keys: string[]) => {
-      setValue(name, keys.join(','));
+      setValue(name, keys);
     },
     [setValue, name]
   );

--- a/src/renderer/components/editor/index.tsx
+++ b/src/renderer/components/editor/index.tsx
@@ -47,7 +47,7 @@ const Editor = () => {
           ...values,
           actionConfig: {
             exePath: values.exePath,
-            bindings: values.bindings?.split(','),
+            bindings: values.bindings,
             url: values.url,
             pageId: values.destinationPageId,
             soundPath: values.soundPath,


### PR DESCRIPTION
# Issue https://github.com/willianrod/ODeck/issues/19
Each binding is an array of keys. To show it, the input was using `join(",")` to show it formatted. This was causing an issue because when submitting the form `split(',')` was required. So when splitting `","` was resulting in `["", ""]`

# Solution
To fix it I just removed split and join because it was not required