### PR TITLE
fix: use cwd option on executable-handler

### DIFF
--- a/src/server/handlers/executable-handler.ts
+++ b/src/server/handlers/executable-handler.ts
@@ -1,10 +1,12 @@
+import path from 'path';
 import { IButtonKey } from '../../interfaces';
 
 const exec = require('child_process').execFile;
 
 export const executableHandler = (keyPressed: IButtonKey) => {
   if (!keyPressed.actionConfig.exePath) return;
-  exec(keyPressed.actionConfig.exePath);
+  const cwd = path.dirname(keyPressed.actionConfig.exePath);
+  exec(keyPressed.actionConfig.exePath, undefined, { cwd });
 };
 
 export default null;


### PR DESCRIPTION
closes #16 

as i commented in the issue, the OBS (and many other softwares) uses the current working directory (cwd) to find configuration and other files. Add cwd path as opening file options solve the problem.