### PR TITLE
[feature] allow to reorder keys

### DIFF
--- a/src/renderer/components/key/index.tsx
+++ b/src/renderer/components/key/index.tsx
@@ -1,9 +1,9 @@
 import { HandlerItem, IButton, IButtonKey } from 'interfaces';
-import React, { useCallback, useEffect, useMemo, useRef } from 'react';
+import React, { useCallback, useMemo, useRef } from 'react';
 import { useDrag, useDrop } from 'react-dnd';
 import { useSelector, useDispatch } from 'react-redux';
 import ItemTypes from 'renderer/constants/item-types.constants';
-import { createKey, deleteKey, setCurrentKey, updateKey } from 'renderer/redux/ducks/keys';
+import { setCurrentKey, updateKey } from 'renderer/redux/ducks/keys';
 
 import overlay from '../../public/button-overlay.png';
 import styles from './key.module.scss';

--- a/src/renderer/components/key/index.tsx
+++ b/src/renderer/components/key/index.tsx
@@ -1,4 +1,4 @@
-import { HandlerItem, IButton, IButtonKey } from 'interfaces';
+import { IButton, IButtonKey } from 'interfaces';
 import React, { useCallback, useMemo, useRef } from 'react';
 import { useDrag, useDrop } from 'react-dnd';
 import { useSelector, useDispatch } from 'react-redux';
@@ -43,14 +43,14 @@ const Key: React.FC<IKey> = ({ button }) => {
     [keys, button]
   );
 
-  const [{ isDragging }, drag] = useDrag(
+  const [, drag] = useDrag(
     () => ({
       type: ItemTypes.KEY,
       item: buttonKey,
       canDrag: () => {
         return !!buttonKey;
       },
-      end: (dropedItem: HandlerItem, monitor) => {
+      end: (_, monitor) => {
         const dropResult = monitor.getDropResult() as any;
 
         if (!dropResult) {
@@ -58,7 +58,9 @@ const Key: React.FC<IKey> = ({ button }) => {
         }
 
         const newPosition = dropResult?.button?.id;
-        const exists = keys?.find((key: IButtonKey) => newPosition === key.position);
+        const exists = keys?.find(
+          (key: IButtonKey) => newPosition === key.position
+        );
         if (exists) {
           return;
         }
@@ -79,7 +81,8 @@ const Key: React.FC<IKey> = ({ button }) => {
 
   const buttonStyle = useMemo<React.HTMLAttributes<HTMLDivElement>>(
     () => ({
-      backgroundColor: buttonKey?.backgroundColor || 'var(--chakra-colors-chakra-body-bg)',
+      backgroundColor:
+        buttonKey?.backgroundColor || 'var(--chakra-colors-chakra-body-bg)',
       color: buttonKey?.color,
       width: 70,
       height: 70,

--- a/src/renderer/components/key/index.tsx
+++ b/src/renderer/components/key/index.tsx
@@ -71,10 +71,6 @@ const Key: React.FC<IKey> = ({ button }) => {
         };
         dispatch(updateKey(newKey));
       },
-      collect: (monitor) => ({
-        isDragging: monitor.isDragging(),
-        handlerId: monitor.getHandlerId(),
-      }),
     }),
     [dispatch, buttonKey]
   );

--- a/src/renderer/components/key/index.tsx
+++ b/src/renderer/components/key/index.tsx
@@ -78,7 +78,9 @@ const Key: React.FC<IKey> = ({ button }) => {
   const buttonStyle = useMemo<React.HTMLAttributes<HTMLDivElement>>(
     () => ({
       backgroundColor:
-        buttonKey?.backgroundColor || 'var(--chakra-colors-chakra-body-bg)',
+        buttonKey?.backgroundColor !== 'transparent'
+          ? buttonKey?.backgroundColor
+          : 'var(--chakra-colors-chakra-body-bg)',
       color: buttonKey?.color,
       width: 70,
       height: 70,

--- a/src/renderer/components/key/index.tsx
+++ b/src/renderer/components/key/index.tsx
@@ -109,25 +109,23 @@ const Key: React.FC<IKey> = ({ button }) => {
   drag(drop(ref));
 
   return (
-    <>
-      <div
-        ref={ref}
-        style={buttonStyle}
-        onClick={handleSelectKey}
-        role="button"
-        tabIndex={-1}
-      >
-        <img
-          src={overlay}
-          alt="overlay"
-          draggable={false}
-          className={styles.buttonOverlay}
-        />
-        {!buttonKey?.hideLabel && (
-          <span className={styles.buttonLabel}>{buttonKey?.label}</span>
-        )}
-      </div>
-    </>
+    <div
+      ref={ref}
+      style={buttonStyle}
+      onClick={handleSelectKey}
+      role="button"
+      tabIndex={-1}
+    >
+      <img
+        src={overlay}
+        alt="overlay"
+        draggable={false}
+        className={styles.buttonOverlay}
+      />
+      {!buttonKey?.hideLabel && (
+        <span className={styles.buttonLabel}>{buttonKey?.label}</span>
+      )}
+    </div>
   );
 };
 

--- a/src/renderer/components/keypad/index.tsx
+++ b/src/renderer/components/keypad/index.tsx
@@ -21,7 +21,7 @@ const KeyPad = () => {
   );
 
   return (
-    <Box overflow="auto" height="100%">
+    <Box overflow="auto" height="100%" bgColor="chakra-body-bg">
       <Flex
         justifyContent="center"
         alignItems="center"
@@ -35,6 +35,7 @@ const KeyPad = () => {
           gridTemplateRows={`repeat(${device.amountVertical}, minmax(${KEY_SIZE_IN_PIXELS}px, 1fr))`}
           userSelect="none"
           height="fit-content"
+          bgColor="chakra-body-bg"
         >
           {buttons.map((button) => {
             return <Key key={button.id} button={button} />;


### PR DESCRIPTION
Propose to close #34 

https://github.com/willianrod/ODeck/assets/20397491/dcb535d9-1090-42de-9534-30a7fcbf0a47

---

Create an composition of `useDrag` and `useDrop` in the Key component to allow reorder.

---

Notes:

- Added `bgColor="chakra-body-bg"` in the KeyPad component to remove white border on preview dragging Key element.
- Changed the `backgroundColor` in the `buttonStyle` variable to add `--chakra-colors-chakra-body-bg` if the backgroundColor is not found or if it is transparent to prevent from ghost transparent preview element when dragging in some cases:

```js
backgroundColor:
        buttonKey?.backgroundColor !== 'transparent'
          ? buttonKey?.backgroundColor
          : 'var(--chakra-colors-chakra-body-bg)',
```
