### PR TITLE
[feature] Running app background

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -11,7 +11,15 @@
 import 'core-js/stable';
 import 'regenerator-runtime/runtime';
 import path from 'path';
-import { app, BrowserWindow, shell, ipcMain } from 'electron';
+import {
+  app,
+  BrowserWindow,
+  shell,
+  ipcMain,
+  Tray,
+  dialog,
+  Menu,
+} from 'electron';
 import { autoUpdater } from 'electron-updater';
 import log from 'electron-log';
 import MenuBuilder from './menu';
@@ -96,6 +104,28 @@ const createWindow = async () => {
 
   mainWindow.on('closed', () => {
     mainWindow = null;
+  });
+
+  mainWindow.on('close', async (event) => {
+    event.preventDefault();
+    const options = {
+      type: 'question',
+      buttons: ['Cancel', 'Sim, por favor', 'Não, Obrigado'],
+      defaultId: 1,
+      title: 'Question',
+      message: 'Atenção!',
+      detail: 'Deseja ocultar o app sempre que apertar no botão fechar?',
+      checkboxLabel: 'Lembre-se dessa responsta',
+      checkboxChecked: false,
+    };
+    const response = await dialog.showMessageBox(options);
+    if (response.response === 1) {
+      mainWindow?.hide();
+    }
+    if (response.response === 2) {
+      console.log('entrando no if 2');
+      mainWindow?.destroy();
+    }
   });
 
   const menuBuilder = new MenuBuilder(mainWindow);

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -66,6 +66,8 @@ const installExtensions = async () => {
     .catch(console.log);
 };
 
+let tray = null;
+
 const createWindow = async () => {
   if (isDevelopment) {
     await installExtensions();
@@ -126,6 +128,23 @@ const createWindow = async () => {
       console.log('entrando no if 2');
       mainWindow?.destroy();
     }
+  });
+
+  tray = new Tray('assets/icon.ico');
+  tray.setToolTip('ODeck');
+  const contextMenu = Menu.buildFromTemplate([
+    {
+      label: 'Fechar ODeck',
+      type: 'normal',
+      click: () => {
+        mainWindow?.destroy();
+      },
+    },
+  ]);
+  tray.setContextMenu(contextMenu);
+
+  tray.on('click', () => {
+    mainWindow?.show();
   });
 
   const menuBuilder = new MenuBuilder(mainWindow);


### PR DESCRIPTION
about #38 

https://github.com/willianrod/ODeck/assets/94568582/41df5e49-d9dc-43b4-8059-d736baf521f4

I have one question: Would you prefer me to save the `optionPersistence` variable in the database to save the pre-set for the user? In this approach whenever the user closes the app it will show the window dialog again, if I save the database the user won't need to respond to that window anymore.

If yes, what is a better approach for me to do this? because if I make the changes theoretically, the user does not make this option again, so there is no local option in the app.
